### PR TITLE
Add Vietnamese docs and language option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-English | [简体中文](docs/README_zh-CN.md) | [繁體中文](docs/README_zh-TW.md) | [日本語](docs/README_ja-JP.md) | [한국어](docs/README_ko-KR.md)
+English | [简体中文](docs/README_zh-CN.md) | [繁體中文](docs/README_zh-TW.md) | [日本語](docs/README_ja-JP.md) | [한국어](docs/README_ko-KR.md) | [Tiếng Việt](docs/README_vi-VN.md)
 
 <img src="./docs/images/banner.png" width="320px"  alt="PDF2ZH"/>
 

--- a/docs/README_GUI.md
+++ b/docs/README_GUI.md
@@ -29,6 +29,7 @@ The following languages are supported:
 - Russian
 - Spanish
 - Italian
+- Vietnamese
 
 ## Preview
 

--- a/docs/README_ja-JP.md
+++ b/docs/README_ja-JP.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-[English](../README.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | 日本語
+[English](../README.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | 日本語 | [Tiếng Việt](README_vi-VN.md)
 
 <img src="./images/banner.png" width="320px"  alt="PDF2ZH"/>  
 

--- a/docs/README_ko-KR.md
+++ b/docs/README_ko-KR.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-[English](../README.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [日本語](README_ja-JP.md) | 한국어
+[English](../README.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [日本語](README_ja-JP.md) | 한국어 | [Tiếng Việt](README_vi-VN.md)
 
 <img src="./images/banner.png" width="320px"  alt="PDF2ZH"/>
 

--- a/docs/README_vi-VN.md
+++ b/docs/README_vi-VN.md
@@ -1,0 +1,24 @@
+<div align="center">
+
+[English](../README.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [日本語](README_ja-JP.md) | [한국어](README_ko-KR.md) | Tiếng Việt
+
+<img src="./images/banner.png" width="320px"  alt="PDF2ZH"/>
+
+<h2 id="title">PDFMathTranslate</h2>
+
+</div>
+
+Công cụ dịch và so sánh song ngữ cho tài liệu khoa học ở định dạng PDF.
+
+- 📊 Giữ nguyên công thức, biểu đồ, mục lục và chú thích *(xem [minh họa](#preview))*.
+- 🌐 Hỗ trợ [nhiều ngôn ngữ](#language) và đa dạng [dịch vụ dịch thuật](#services).
+- 🤖 Cung cấp [dòng lệnh](#usage), [giao diện người dùng](#gui) và [Docker](#docker).
+
+Bạn có thể phản hồi tại [GitHub Issues](https://github.com/Byaidu/PDFMathTranslate/issues) hoặc nhóm [Telegram](https://t.me/+Z9_SgnxmsmA5NzBl).
+
+<h2 id="preview">Minh họa</h2>
+
+<div align="center">
+<img src="./images/preview.gif" width="80%"/>
+</div>
+

--- a/docs/README_zh-CN.md
+++ b/docs/README_zh-CN.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-[English](../README.md) | 简体中文 | [繁體中文](README_zh-TW.md) | [日本語](README_ja-JP.md)
+[English](../README.md) | 简体中文 | [繁體中文](README_zh-TW.md) | [日本語](README_ja-JP.md) | [Tiếng Việt](README_vi-VN.md)
 
 <img src="./images/banner.png" width="320px"  alt="PDF2ZH"/>  
 

--- a/docs/README_zh-TW.md
+++ b/docs/README_zh-TW.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-[English](../README.md) | [简体中文](README_zh-CN.md) | 繁體中文 | [日本語](README_ja-JP.md)
+[English](../README.md) | [简体中文](README_zh-CN.md) | 繁體中文 | [日本語](README_ja-JP.md) | [Tiếng Việt](README_vi-VN.md)
 
 <img src="./images/banner.png" width="320px"  alt="PDF2ZH"/>  
 

--- a/pdf2zh/gui.py
+++ b/pdf2zh/gui.py
@@ -87,6 +87,7 @@ lang_map = {
     "Russian": "ru",
     "Spanish": "es",
     "Italian": "it",
+    "Vietnamese": "vi",
 }
 
 # The following variable associate strings with page ranges

--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -1026,6 +1026,7 @@ class QwenMtTranslator(OpenAITranslator):
             "ru": "Russian",
             "es": "Spanish",
             "it": "Italian",
+            "vi": "Vietnamese",
         }
 
         return langdict[input_lang]


### PR DESCRIPTION
## Summary
- add Vietnamese docs
- link to Vietnamese version in all READMEs
- support Vietnamese in GUI and translators
- document Vietnamese as a supported language

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_68523987852c83258b598262a3e3bdd3